### PR TITLE
feat: define DynamoDB schema and entity types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.57.0",
         "prettier": "^3.3.0",
+        "tsx": "^4.0.0",
         "typescript": "^5.5.0"
       }
     },
@@ -757,6 +760,448 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2839,6 +3284,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3353,6 +3840,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3410,6 +3912,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -4457,6 +4972,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4994,6 +5519,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "format": "prettier --write ."
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.57.0",
     "prettier": "^3.3.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.5.0"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,8 @@
 // packages/core — pure business logic
 // No AWS, no Discord. All functions take data as arguments and return results.
-// Implemented in Issue 3.
-export {};
+
+// Entity types and enums — defined in Issue 2
+export * from "./types.js";
+
+// Business logic modules — implemented in Issue 3
+// availability.ts, participation.ts, cutoff.ts, validation.ts, constants.ts

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,150 @@
+// =============================================================================
+// Enums
+// String union types used as enums. These constrain the values stored in
+// DynamoDB and enforced by the bot command handlers.
+// =============================================================================
+
+export type Role = "EMPLOYEE" | "TEAM_LEAD" | "ADMIN" | "LOGISTICS";
+
+export type UserStatus = "ACTIVE" | "INACTIVE";
+
+export type MealType =
+  | "LUNCH"
+  | "SNACKS"
+  | "IFTAR"
+  | "EVENT_DINNER"
+  | "OPTIONAL_DINNER";
+
+export type MealStatus = "IN" | "OUT";
+
+export type Location = "OFFICE" | "WFH";
+
+export type SpecialDayType = "OFFICE_CLOSED" | "GOVT_HOLIDAY" | "CELEBRATION";
+
+export type JobStatus = "PENDING" | "PROCESSING" | "READY" | "FAILED";
+
+// =============================================================================
+// Entity Interfaces
+// These map directly to DynamoDB table records. Attribute names match the
+// DynamoDB attribute names exactly so there is no mapping layer needed.
+// =============================================================================
+
+/**
+ * Users table
+ * PK: userId (format: u#<discordId>)
+ * GSI: discordId-index (PK: discordId)
+ */
+export interface User {
+  userId: string;       // u#<discordId> — internal identity namespace
+  discordId: string;    // Discord snowflake ID — used for GSI lookup
+  name: string;         // Display name shown in summaries
+  role: Role;
+  teamId: string | null; // null for ADMIN and LOGISTICS roles
+  status: UserStatus;
+}
+
+/**
+ * Participation table
+ * PK: date (YYYY-MM-DD)   SK: userId#mealType (e.g. u#123456789#LUNCH)
+ * GSI: userId-date-index (PK: userId, SK: date)
+ *
+ * Absence of a record means the meal's default status applies.
+ * Only exceptions to defaults are stored.
+ */
+export interface ParticipationRecord {
+  date: string;               // YYYY-MM-DD
+  "userId#mealType": string;  // composite SK: u#<discordId>#<mealType>
+  userId: string;             // stored separately for GSI
+  mealType: MealType;
+  status: MealStatus;
+  updatedBy: string;          // userId of the actor (may differ from record owner for admin overrides)
+  updatedAt: string;          // ISO 8601 timestamp
+}
+
+/**
+ * WorkLocations table
+ * PK: date (YYYY-MM-DD)   SK: userId
+ *
+ * Absence of a record means OFFICE (default).
+ * WFH users are excluded from ALL meal headcounts regardless of participation records.
+ */
+export interface WorkLocation {
+  date: string;       // YYYY-MM-DD
+  userId: string;
+  location: Location;
+  updatedBy: string;  // userId of the actor
+  updatedAt: string;  // ISO 8601 timestamp
+}
+
+/**
+ * SpecialDays table
+ * PK: yearMonth (YYYY-MM)   SK: date (YYYY-MM-DD)
+ *
+ * yearMonth as PK enables both single-date lookup (GetItem) AND
+ * list-by-month (Query PK=yearMonth) without a GSI.
+ */
+export interface SpecialDay {
+  yearMonth: string;          // YYYY-MM — partition key
+  date: string;               // YYYY-MM-DD — sort key
+  type: SpecialDayType;
+  note: string | null;        // optional description
+  meals: MealType[];          // extra meals for CELEBRATION days (e.g. EVENT_DINNER)
+  createdBy: string;          // userId of creator
+  updatedAt: string;          // ISO 8601 timestamp
+}
+
+/**
+ * Settings table
+ * PK: settingId — always "global" (single record)
+ *
+ * All reads are GetItem PK="global". All writes replace the full record.
+ * Cutoff time is NOT stored here — it is hardcoded as CUTOFF_HOUR in constants.ts.
+ */
+export interface IftarPeriod {
+  label: string;      // e.g. "Ramadan 2026"
+  startDate: string;  // YYYY-MM-DD
+  endDate: string;    // YYYY-MM-DD
+}
+
+export interface CompanyWfhPeriod {
+  startDate: string;  // YYYY-MM-DD
+  endDate: string;    // YYYY-MM-DD
+  reason: string;
+}
+
+export interface Settings {
+  settingId: "global";               // always "global" — enforced by type
+  offDays: number[];                 // day-of-week: 0=Sun, 6=Sat. Default: [0, 6]
+  iftarPeriods: IftarPeriod[];       // empty until admin configures
+  companyWfhPeriods: CompanyWfhPeriod[]; // empty until admin configures
+  maxForwardPlanningDays: number;    // default: 14
+}
+
+/**
+ * SummaryJobs table
+ * PK: date (YYYY-MM-DD)   SK: jobId (UUID)
+ *
+ * Coordinates async summary generation between the bot Lambda (creates job)
+ * and the worker Lambda (processes job). Discord requires a response within
+ * 3 seconds — the async pattern guarantees this.
+ */
+export interface SummaryJob {
+  date: string;                 // YYYY-MM-DD — the date the summary covers
+  jobId: string;                // UUID
+  status: JobStatus;
+  result: SummaryResult | null; // populated when status = READY
+  errorMessage: string | null;  // populated when status = FAILED
+  triggeredBy: string;          // userId of admin who triggered
+  createdAt: string;            // ISO 8601
+  updatedAt: string;            // ISO 8601
+}
+
+/**
+ * Computed result stored in SummaryJob when status = READY.
+ * Populated by the worker Lambda after calling computeHeadcount() from packages/core.
+ * Full HeadcountReport type is defined in Issue 3 (participation.ts).
+ */
+export interface SummaryResult {
+  date: string;
+  formattedMessage: string; // the Discord-formatted summary message
+}

--- a/packages/infra/src/tables.ts
+++ b/packages/infra/src/tables.ts
@@ -1,0 +1,133 @@
+/**
+ * Defines all 6 DynamoDB tables for MHP.
+ *
+ * Called from sst.config.ts inside run(). Returns all table constructs so
+ * sst.config.ts can pass their names as environment variables to Lambda functions.
+ *
+ * Billing: PAY_PER_REQUEST is SST's default — no override needed.
+ *
+ * GSI budget: 2 total across all tables.
+ * - discordId-index on Users        (every bot command resolves discordId → user)
+ * - userId-date-index on Participation  (employee status view)
+ */
+export function createTables() {
+  // ---------------------------------------------------------------------------
+  // Users
+  // PK: userId (format: u#<discordId>)
+  // GSI: discordId-index — resolves Discord user → internal user on every command.
+  // Without this GSI every bot command would require a full table scan.
+  // ---------------------------------------------------------------------------
+  const usersTable = new sst.aws.Dynamo("Users", {
+    fields: {
+      userId: "string",
+      discordId: "string",
+    },
+    primaryIndex: {
+      hashKey: "userId",
+    },
+    globalIndexes: {
+      "discordId-index": {
+        hashKey: "discordId",
+      },
+    },
+  });
+
+  // ---------------------------------------------------------------------------
+  // Participation
+  // PK: date (YYYY-MM-DD)   SK: userId#mealType (e.g. u#123456789#LUNCH)
+  // Composite SK enables prefix queries: begins_with("u#123") = one user's meals.
+  // GSI: userId-date-index — employee status view (user first, then date).
+  // ---------------------------------------------------------------------------
+  const participationTable = new sst.aws.Dynamo("Participation", {
+    fields: {
+      date: "string",
+      "userId#mealType": "string",
+      userId: "string",
+    },
+    primaryIndex: {
+      hashKey: "date",
+      rangeKey: "userId#mealType",
+    },
+    globalIndexes: {
+      "userId-date-index": {
+        hashKey: "userId",
+        rangeKey: "date",
+      },
+    },
+  });
+
+  // ---------------------------------------------------------------------------
+  // WorkLocations
+  // PK: date (YYYY-MM-DD)   SK: userId
+  // Absence of a record means OFFICE (default).
+  // No GSI in this iteration — monthly history deferred to WFH overage report feature.
+  // ---------------------------------------------------------------------------
+  const workLocationsTable = new sst.aws.Dynamo("WorkLocations", {
+    fields: {
+      date: "string",
+      userId: "string",
+    },
+    primaryIndex: {
+      hashKey: "date",
+      rangeKey: "userId",
+    },
+  });
+
+  // ---------------------------------------------------------------------------
+  // SpecialDays
+  // PK: yearMonth (YYYY-MM)   SK: date (YYYY-MM-DD)
+  // yearMonth as PK enables both single-date lookup AND list-by-month without a GSI.
+  // If date were the PK, listing a month's special days would require a full scan.
+  // ---------------------------------------------------------------------------
+  const specialDaysTable = new sst.aws.Dynamo("SpecialDays", {
+    fields: {
+      yearMonth: "string",
+      date: "string",
+    },
+    primaryIndex: {
+      hashKey: "yearMonth",
+      rangeKey: "date",
+    },
+  });
+
+  // ---------------------------------------------------------------------------
+  // Settings
+  // PK: settingId — always "global" (single record table).
+  // All reads are GetItem PK="global". All writes replace the full record.
+  // No SK, no GSI needed.
+  // ---------------------------------------------------------------------------
+  const settingsTable = new sst.aws.Dynamo("Settings", {
+    fields: {
+      settingId: "string",
+    },
+    primaryIndex: {
+      hashKey: "settingId",
+    },
+  });
+
+  // ---------------------------------------------------------------------------
+  // SummaryJobs
+  // PK: date (YYYY-MM-DD)   SK: jobId (UUID)
+  // Jobs are looked up by the date they cover, not by job ID.
+  // SK ensures uniqueness when multiple jobs exist for the same date (retries).
+  // ---------------------------------------------------------------------------
+  const summaryJobsTable = new sst.aws.Dynamo("SummaryJobs", {
+    fields: {
+      date: "string",
+      jobId: "string",
+    },
+    primaryIndex: {
+      hashKey: "date",
+      rangeKey: "jobId",
+    },
+  });
+
+  return {
+    usersTable,
+    participationTable,
+    workLocationsTable,
+    specialDaysTable,
+    settingsTable,
+    summaryJobsTable,
+  };
+}

--- a/packages/infra/tsconfig.json
+++ b/packages/infra/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "src",
     "outDir": "dist"
   },
+  "files": ["../../.sst/platform/config.d.ts"],
   "include": ["src"]
 }

--- a/scripts/seed-settings.ts
+++ b/scripts/seed-settings.ts
@@ -1,0 +1,56 @@
+/**
+ * seed-settings.ts
+ *
+ * Writes the initial Settings record to DynamoDB with default values.
+ * Safe to run multiple times — uses PutItem which overwrites the same key.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-settings.ts
+ *
+ * Prerequisites:
+ *   - AWS credentials configured (aws configure or AWS_PROFILE env var)
+ *   - SETTINGS_TABLE env var set (copy .env.example to .env and fill in)
+ *   - SST has been deployed at least once so the table exists (npx sst deploy)
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { Settings } from "../packages/core/src/types.js";
+
+const tableName = process.env.SETTINGS_TABLE;
+if (!tableName) {
+  console.error("Error: SETTINGS_TABLE environment variable is not set.");
+  console.error("Copy .env.example to .env and set the SETTINGS_TABLE value.");
+  process.exit(1);
+}
+
+const region = process.env.AWS_REGION ?? "ap-southeast-1";
+const client = new DynamoDBClient({ region });
+const docClient = DynamoDBDocumentClient.from(client);
+
+const defaultSettings: Settings = {
+  settingId: "global",
+  offDays: [0, 6],          // 0 = Sunday, 6 = Saturday
+  iftarPeriods: [],          // admin configures when Ramadan begins
+  companyWfhPeriods: [],     // admin configures when needed
+  maxForwardPlanningDays: 14,
+};
+
+async function seedSettings(): Promise<void> {
+  console.log(`Seeding Settings table: ${tableName}`);
+  console.log("Record:", JSON.stringify(defaultSettings, null, 2));
+
+  await docClient.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: defaultSettings,
+    })
+  );
+
+  console.log("Done. Settings record written (settingId = 'global').");
+}
+
+seedSettings().catch((err) => {
+  console.error("Failed to seed settings:", err);
+  process.exit(1);
+});

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,4 +1,4 @@
-/// <reference path="./.sst/platform/config.d.ts" />
+/// <reference path="./.sst/platform/config.d.ts" /> // eslint-disable-line @typescript-eslint/triple-slash-reference
 
 export default $config({
   app(input) {
@@ -9,6 +9,27 @@ export default $config({
     };
   },
   async run() {
-    // AWS resources (DynamoDB tables, Lambda, API Gateway, SQS) added in subsequent issues.
+    const { createTables } = await import("./packages/infra/src/tables.js");
+
+    const {
+      usersTable,
+      participationTable,
+      workLocationsTable,
+      specialDaysTable,
+      settingsTable,
+      summaryJobsTable,
+    } = createTables();
+
+    // Table names returned here so they appear in sst outputs.
+    // Lambda functions (added in Issue 4) will receive these as environment
+    // variables: environment: { USERS_TABLE: usersTable.name, ... }
+    return {
+      usersTable: usersTable.name,
+      participationTable: participationTable.name,
+      workLocationsTable: workLocationsTable.name,
+      specialDaysTable: specialDaysTable.name,
+      settingsTable: settingsTable.name,
+      summaryJobsTable: summaryJobsTable.name,
+    };
   },
 });


### PR DESCRIPTION
**Closes:** #2
**Dependencies:** Implementation PR for Issue 1 must be merged first.

---

## What does this PR do?

Defines the DynamoDB data layer. Six tables are provisioned via SST, TypeScript entity interfaces are added to `packages/core`, and a seed script writes the initial Settings record. No Lambda handlers read or write these tables yet — that begins in Issue 5.

**Design document:** [docs/i2-dynamodb-schema.md](https://github.com/mehedi-1101/mhp-v2/blob/docs/issue-2-dynamodb-schema/docs/i2-dynamodb-schema.md)

## Type of Change

- [x] New feature

## What was changed

- `packages/infra/src/tables.ts` — 6 SST `Dynamo` constructs with all keys and indexes
- `packages/infra/tsconfig.json` — loads SST global types via `files[]` so `sst.*` globals are available across infra source files
- `sst.config.ts` — dynamically imports `createTables()`, returns table names as SST outputs (Lambda env var wiring done in Issue 4)
- `packages/core/src/types.ts` — entity interfaces and enums for all 6 tables
- `packages/core/src/index.ts` — re-exports from `types.ts`
- `scripts/seed-settings.ts` — writes the initial `global` Settings record, idempotent
- `package.json` (root) — added `@aws-sdk`, `tsx` as devDependencies for scripts

**Tables defined:**

| Table | PK | SK | GSI |
|---|---|---|---|
| Users | `userId` | — | `discordId-index` |
| Participation | `date` | `userId#mealType` | `userId-date-index` |
| WorkLocations | `date` | `userId` | none (deferred) |
| SpecialDays | `yearMonth` | `date` | none |
| Settings | `settingId` | — | none |
| SummaryJobs | `date` | `jobId` | none |

**Key decisions made during implementation:**

- `PAY_PER_REQUEST` is SST's default — no override needed
- `sst.config.ts` uses `await import()` instead of a top-level import — SST v3 does not allow top-level imports in `sst.config.ts`
- Entity attribute names in `types.ts` match DynamoDB exactly (including `"userId#mealType"` as a quoted key) — no mapping layer needed

## Changelog

None: not user visible — data layer only.

## How to Test

```bash
npm run typecheck   # zero errors
npm run lint        # zero errors
npx sst install     # should complete: "Installed providers"
```

## Rollback Plan

No AWS resources are created by this PR alone — SST only synthesizes, it does not deploy. The seed script is run manually after a deploy. Reverting leaves the project at the Issue 1 scaffold state with no AWS side effects.

## Checklist

- [x] All 6 tables defined with correct keys per design doc
- [x] Exactly 2 GSIs — `discordId-index` on Users, `userId-date-index` on Participation
- [x] No GSI on WorkLocations (deferred per design doc)
- [x] Entity interfaces in `packages/core/src/types.ts` match DynamoDB attribute names exactly
- [x] Seed script is idempotent
- [x] `npm run typecheck` passes across all packages
- [x] `npm run lint` passes across all packages
- [x] No business logic or Lambda handlers in this PR

## Note for Reviewer

- `types.ts` covers entity interfaces only — computed types (`HeadcountReport`, `MealAvailability`) are Issue 3's scope
- WorkLocations GSI is intentionally absent — deferred to the WFH overage report iteration per design doc
